### PR TITLE
Fixed error where ExprFunc used an uninitialized factorIntMat.

### DIFF
--- a/src/ExprFunc.cpp
+++ b/src/ExprFunc.cpp
@@ -4,7 +4,7 @@
 #include "ExprPar.h"
 
 //#define DEBUG
-ExprFunc::ExprFunc( const ExprModel* _model, const ExprPar& _par , const SiteVec& sites_, const int seq_len, const int seq_num): expr_model(_model), par(_par), motifs( _model->motifs ), actIndicators( _model->actIndicators ), maxContact( _model->maxContact ), repIndicators( _model->repIndicators ), repressionMat( _model->repressionMat ), repressionDistThr( _model->repressionDistThr ), factorIntMat(_model->motifs.size(),_model->motifs.size())
+ExprFunc::ExprFunc( const ExprModel* _model, const ExprPar& _par , const SiteVec& sites_, const int seq_len, const int seq_num): expr_model(_model), par(_par), motifs( _model->motifs ), actIndicators( _model->actIndicators ), maxContact( _model->maxContact ), repIndicators( _model->repIndicators ), repressionMat( _model->repressionMat ), repressionDistThr( _model->repressionDistThr ), factorIntMat(_model->motifs.size(),_model->motifs.size(),1.0)
 {
     //par = _par;//NOTE: made this const, and that solved a memory leak.
 

--- a/src/ExprModel.cpp
+++ b/src/ExprModel.cpp
@@ -124,7 +124,9 @@ int CoopInfo::get_longest_coop_thr() const {
 
 void CoopInfo::read_coop_file(string filename, map<string, int> factorIdxMap){
 
-        ifstream fin( filename.c_str() );
+        ifstream fin;
+		fin.exceptions ( std::ifstream::failbit | std::ifstream::badbit );
+		fin.open( filename.c_str(), std::ifstream::in );
 
         std:string line;
         std::istringstream line_ss;

--- a/src/ExprModel.cpp
+++ b/src/ExprModel.cpp
@@ -125,7 +125,7 @@ int CoopInfo::get_longest_coop_thr() const {
 void CoopInfo::read_coop_file(string filename, map<string, int> factorIdxMap){
 
         ifstream fin;
-		fin.exceptions ( std::ifstream::failbit | std::ifstream::badbit );
+		fin.exceptions ( std::ifstream::failbit);// | std::ifstream::badbit );
 		fin.open( filename.c_str(), std::ifstream::in );
 
         std:string line;
@@ -139,6 +139,9 @@ void CoopInfo::read_coop_file(string filename, map<string, int> factorIdxMap){
                                 back_inserter(M_TOK_VECT))
 
         while(std::getline(fin,line)){
+				if(fin.bad()){
+					throw std::runtime_error("Badbit set");
+				}
                 LOCAL_TOKENIZE(tokens,line,line_ss);
                 int tf_i = factorIdxMap[tokens[0]];
                 int tf_j = factorIdxMap[tokens[1]];
@@ -257,6 +260,12 @@ void CoopInfo::read_coop_file(string filename, map<string, int> factorIdxMap){
         //cerr << coop_matrix << endl;
 
         //exit(1);
+		/*
+		//TODO: It seems I don't fully understand C++ file error states. This always raises an exception.
+		if(fin.bad()){
+			throw std::runtime_error("badbit");
+		}
+		*/
         fin.close();
         //cerr << "finished reading file" << endl;
 }

--- a/src/ExprModel.cpp
+++ b/src/ExprModel.cpp
@@ -125,7 +125,7 @@ int CoopInfo::get_longest_coop_thr() const {
 void CoopInfo::read_coop_file(string filename, map<string, int> factorIdxMap){
 
         ifstream fin;
-		fin.exceptions ( std::ifstream::failbit);// | std::ifstream::badbit );
+		//fin.exceptions ( std::ifstream::failbit);// | std::ifstream::badbit );
 		fin.open( filename.c_str(), std::ifstream::in );
 
         std:string line;
@@ -143,8 +143,17 @@ void CoopInfo::read_coop_file(string filename, map<string, int> factorIdxMap){
 					throw std::runtime_error("Badbit set");
 				}
                 LOCAL_TOKENIZE(tokens,line,line_ss);
-                int tf_i = factorIdxMap[tokens[0]];
-                int tf_j = factorIdxMap[tokens[1]];
+
+                if(tokens.size() == 0){
+                  continue;//Empty line
+                }
+
+                if(tokens.size() < 2){
+                  throw std::runtime_error("Encountered a line that could not be parsed while reading " + filename );
+                }
+
+                int tf_i = factorIdxMap.at(tokens[0]);
+                int tf_j = factorIdxMap.at(tokens[1]);
 
                 //Using default interaction func in both directions
                 int forward_func = 1;

--- a/src/ExprPar.cpp
+++ b/src/ExprPar.cpp
@@ -468,7 +468,7 @@ ExprPar ParFactory::load(const string& file){
   ExprPar ret_par;
   // open the file
   ifstream fin;
-  fin.exceptions ( std::ifstream::failbit | std::ifstream::badbit );
+  //fin.exceptions ( std::ifstream::failbit | std::ifstream::badbit ); //TODO: Decide on some better exception handling.
   fin.open( file.c_str(), std::ifstream::in );
   if ( !fin ){ cerr << "Cannot open parameter file " << file << endl; exit( 1 ); }
 

--- a/src/ExprPar.cpp
+++ b/src/ExprPar.cpp
@@ -467,7 +467,9 @@ ExprPar ParFactory::randSamplePar( const gsl_rng* rng) const
 ExprPar ParFactory::load(const string& file){
   ExprPar ret_par;
   // open the file
-  ifstream fin( file.c_str() );
+  ifstream fin;
+  fin.exceptions ( std::ifstream::failbit | std::ifstream::badbit );
+  fin.open( file.c_str(), std::ifstream::in );
   if ( !fin ){ cerr << "Cannot open parameter file " << file << endl; exit( 1 ); }
 
   std::string header;

--- a/src/ObjFunc.cpp
+++ b/src/ObjFunc.cpp
@@ -211,7 +211,7 @@ double Weighted_RMSEObjFunc::eval(const vector<vector<double> >& ground_truth, c
     return rmse;
 }
 
-void Weighted_RMSEObjFunc::set_weights(Matrix *in_weights){
+void Weighted_ObjFunc_Mixin::set_weights(Matrix *in_weights){
     if(NULL != weights){delete weights;}
     weights = in_weights;
 

--- a/src/ObjFunc.h
+++ b/src/ObjFunc.h
@@ -3,6 +3,18 @@
 
 #include "ExprPar.h"
 
+class Weighted_ObjFunc_Mixin {
+  public:
+    Weighted_ObjFunc_Mixin() : weights(NULL) {}
+    ~Weighted_ObjFunc_Mixin(){if(NULL != weights){delete weights;}}
+
+    virtual void set_weights(Matrix *in_weights);//Some child classes might autocreate weights
+    virtual Matrix* get_weights(){ return weights;}
+  protected:
+      Matrix *weights;
+      double total_weight;
+};
+
 class ObjFunc {
 public:
   ObjFunc(){}
@@ -54,6 +66,9 @@ private:
   double bias;
 };
 
+/**
+Decorator/container objective function, it wraps other objective functions.
+*/
 class RegularizedObjFunc: public ObjFunc {
 public:
   RegularizedObjFunc(ObjFunc* wrapped_obj_func, const ExprPar& centers, const ExprPar& l1, const ExprPar& l2);
@@ -70,22 +85,19 @@ private:
   //vector<double> cache_sq_diffs;
 };
 
+//TODO: Make this class also inherit from Weighted_ObjFunc_Mixin and explicitly calculate a weight matrix.
 class PeakWeightedObjFunc: public ObjFunc {
 public:
   ~PeakWeightedObjFunc(){}
   double eval(const vector<vector<double> >& ground_truth, const vector<vector<double> >& prediction, const ExprPar* par);
 };
 
-class Weighted_RMSEObjFunc: public RMSEObjFunc {
+class Weighted_RMSEObjFunc: public RMSEObjFunc, public Weighted_ObjFunc_Mixin {
 public:
-    Weighted_RMSEObjFunc() : RMSEObjFunc(), weights(NULL) {}
-  ~Weighted_RMSEObjFunc(){if(NULL != weights){delete weights;}}
+    Weighted_RMSEObjFunc() : RMSEObjFunc(), Weighted_ObjFunc_Mixin() {}
+    ~Weighted_RMSEObjFunc(){};
   double eval(const vector<vector<double> >& ground_truth, const vector<vector<double> >& prediction, const ExprPar* par);
 
-  void set_weights(Matrix *in_weights);
-private:
-    Matrix *weights;
-    double total_weight;
 };
 
 #endif

--- a/src/ObjFunc.h
+++ b/src/ObjFunc.h
@@ -10,6 +10,7 @@ class Weighted_ObjFunc_Mixin {
 
     virtual void set_weights(Matrix *in_weights);//Some child classes might autocreate weights
     virtual Matrix* get_weights(){ return weights;}
+    virtual double get_total_weight(){return total_weight;}
   protected:
       Matrix *weights;
       double total_weight;

--- a/src/SeqAnnotator.cpp
+++ b/src/SeqAnnotator.cpp
@@ -159,7 +159,7 @@ int Sequence::load( const string& file, string& name, int format )
     vector< Sequence > seqs;
     vector< string > names;
     int rval = readSequences( file, seqs, names, format );
-    if ( rval == RET_ERROR ) return RET_ERROR;
+    if ( rval == RET_ERROR ) return RET_ERROR; //TODO: throw an exception
 
     copy( seqs[ 0 ] );
     name = names[ 0 ];
@@ -191,13 +191,13 @@ ostream& operator<<( ostream& os, const Sequence& seq )
 int readSequences( const string& file, vector< Sequence >& seqs, vector< string >& names, int format )
 {
     // check if the format character is legal
-    if ( format != FASTA ) { return RET_ERROR; }
+    if ( format != FASTA ) { return RET_ERROR; }//TODO: throw an exception
     seqs.clear();
     names.clear();
 
     // 	open the file
     ifstream fin( file.c_str() );
-    if ( !fin ) { cerr << "Cannot open" << file << endl; return RET_ERROR; }
+    if ( !fin ) { cerr << "Cannot open" << file << endl; return RET_ERROR; }//TODO: throw an exception
 
     string line;
     Sequence seq;
@@ -242,7 +242,7 @@ int readSequences( const string& file, vector< Sequence >& seqs, vector< string 
                     else
                     {
                         cerr << "Illegal symbol: " << nt << " in " << file << endl;
-                        return RET_ERROR;
+                        return RET_ERROR; //TODO: throw an exception
                     }
                 }
             }
@@ -269,7 +269,7 @@ int writeSequences( const string& file, const vector< Sequence >& seqs, const ve
     assert( seqs.size() == names.size() );
 
     // check if the format character is legal
-    if ( format != FASTA ) { return RET_ERROR; }
+    if ( format != FASTA ) { return RET_ERROR; }//TODO: throw an exception
 
     ofstream fout( file.c_str() );
 
@@ -405,7 +405,7 @@ int Motif::load( const string& file, const vector< double >& background, string&
     vector< Motif > motifs;
     vector< string > names;
     int rval = readMotifs( file, background, motifs, names );
-    if ( rval == RET_ERROR ) return RET_ERROR;
+    if ( rval == RET_ERROR ) return RET_ERROR;//TODO: throw an exception
 
     copy( motifs[ 0 ] );
     name = names[ 0 ];
@@ -464,7 +464,7 @@ int readMotifs( const string& file, const vector< double >& background, vector< 
 {
     // 	open the file
     ifstream fin( file.c_str() );
-    if ( !fin ) { cerr << "Cannot open" << file << endl; return RET_ERROR; }
+    if ( !fin ) { cerr << "Cannot open" << file << endl; return RET_ERROR; } //TODO: throw an exception
     motifs.clear();
     names.clear();
 
@@ -553,7 +553,7 @@ int readSites( const string& file, const map< string, int >& factorIdxMap, vecto
     ifstream fin( file.c_str() );
     if ( !fin )
     {
-        return RET_ERROR;
+        return RET_ERROR; //TODO: throw an exception
     }
     sites.clear();
     names.clear();

--- a/src/seq2expr.cpp
+++ b/src/seq2expr.cpp
@@ -312,7 +312,15 @@ int main( int argc, char* argv[] )
     // read the cooperativity matrix
     if ( !coopFile.empty() )
     {
-        expr_model.coop_setup->read_coop_file(coopFile, factorIdxMap);
+		try{
+			cerr << "Reading coop file...";
+        	expr_model.coop_setup->read_coop_file(coopFile, factorIdxMap);
+			cerr << "DONE." << endl;
+		}catch(exception& e){
+			cerr << "There was an exception when attempting to read the coop file: '" << coopFile << "'" << endl;
+			cerr << "Its message was: " << endl << e.what() << endl;
+			exit(1);
+		}
     }
     //***** END COOPS *****
 

--- a/src/seq2expr.cpp
+++ b/src/seq2expr.cpp
@@ -361,12 +361,7 @@ int main( int argc, char* argv[] )
 
     if( !free_fix_indicator_filename.empty() )
     {
-<<<<<<< HEAD
         //ExprPar param_ff;
-=======
-		cerr << "Loading free_fix...";
-        ExprPar param_ff;
->>>>>>> develop
         try{
           cerr << "loading free fix" << endl;
           param_ff = param_factory->load( free_fix_indicator_filename );
@@ -392,17 +387,12 @@ int main( int argc, char* argv[] )
           else{ ASSERT_MESSAGE(false,"Illegal value in indicator_bool file");}
         }
 
-<<<<<<< HEAD
 
 
 
     /******* END OF FREE free_fix
     */
 
-=======
-		cerr << "DONE." << endl; //loading free fix.
-    }
->>>>>>> develop
 
 
     /*

--- a/src/seq2expr.cpp
+++ b/src/seq2expr.cpp
@@ -326,6 +326,7 @@ int main( int argc, char* argv[] )
     par_init = param_factory->changeSpace(par_init, PROB_SPACE); //This will cause the expected behaviour, but may hide underlying bugs.
                                                                 //Code that needs par_init in a particular space should use an assertion, and do the space conversion itself.
     if ( !parFile.empty() ){
+		cerr << "Loading initial parameters...";
         try{
           par_init = param_factory->load( parFile );
           read_par_init_file = true;
@@ -333,6 +334,7 @@ int main( int argc, char* argv[] )
             cerr << "Cannot read parameters from " << parFile << endl;
             exit( 1 );
         }
+		cerr << "DONE." << endl;
     }
 
     //Load free_fix from the same format as parameter vectors!
@@ -346,6 +348,7 @@ int main( int argc, char* argv[] )
     #endif
     if( !free_fix_indicator_filename.empty() )
     {
+		cerr << "Loading free_fix...";
         ExprPar param_ff;
         try{
           param_ff = param_factory->load( free_fix_indicator_filename );
@@ -366,6 +369,8 @@ int main( int argc, char* argv[] )
           else if (0.9999999 < one_val && 1.0000001 > one_val){ indicator_bool.push_back(true);}
           else{ ASSERT_MESSAGE(false,"Illegal value in indicator_bool file");}
         }
+
+		cerr << "DONE." << endl; //loading free fix.
     }
 
 
@@ -379,7 +384,9 @@ int main( int argc, char* argv[] )
     */
 
     if ( !upper_bound_file.empty() ){
+		cerr << "Loading upper bounds...";
 	try{
+
 		upper_bound_par = param_factory->load( upper_bound_file );
 		upper_bound_par = param_factory->changeSpace(upper_bound_par, ENERGY_SPACE);
 		upper_bound_par_read = true;
@@ -387,10 +394,13 @@ int main( int argc, char* argv[] )
 		cerr << "Cannot read upper bounds from " << upper_bound_file << endl;
 		exit( 1 );
 	}
+		cerr << "DONE." << endl;
     }
 
     if ( !lower_bound_file.empty() ){
+		cerr << "Loading lower bounds...";
 	try{
+
 		lower_bound_par = param_factory->load( lower_bound_file );
 		lower_bound_par = param_factory->changeSpace(lower_bound_par, ENERGY_SPACE);
 		lower_bound_par_read = true;
@@ -398,6 +408,7 @@ int main( int argc, char* argv[] )
 		cerr << "Cannot read lower bounds from " << lower_bound_file << endl;
 		exit( 1 );
 	}
+		cerr << "DONE." << endl;
     }
 
     //Check AGAIN that the indicator_bool will be the right shape for the parameters that are read.

--- a/src/seq2expr.cpp
+++ b/src/seq2expr.cpp
@@ -702,21 +702,22 @@ int main( int argc, char* argv[] )
     for(gsparams::DictList::iterator itr = par_init.my_pars.begin();itr != par_init.my_pars.end();++itr){
         path_vector.push_back(itr.get_path());
     }
-    vector< gsparams::DictList* > all_loaded_params;
-    all_loaded_params.push_back(&(param_ff.my_pars));
-    all_loaded_params.push_back(&(lower_bound_par.my_pars));
-    all_loaded_params.push_back(&(upper_bound_par.my_pars));
+    vector< std::pair<std::string , gsparams::DictList* > > all_loaded_params;
+
+    all_loaded_params.push_back(std::make_pair("free_fix",&(param_ff.my_pars)));
+    all_loaded_params.push_back(std::make_pair("lower_bounds",&(lower_bound_par.my_pars)));
+    all_loaded_params.push_back(std::make_pair("upper_bounds",&(upper_bound_par.my_pars)));
     /*Only if using l1/l2 regularization*/
     if(setup_regularization){
-        all_loaded_params.push_back(&(tmp_centers.my_pars));
-        all_loaded_params.push_back(&(tmp_l1.my_pars));
-        all_loaded_params.push_back(&(tmp_l2.my_pars));
+        all_loaded_params.push_back(std::make_pair("reg_centers",&(tmp_centers.my_pars)));
+        all_loaded_params.push_back(std::make_pair("l1_weights",&(tmp_l1.my_pars)));
+        all_loaded_params.push_back(std::make_pair("l2_weights",&(tmp_l2.my_pars)));
     }
 
     for(int i = 0;i<all_loaded_params.size();i++){
-        gsparams::DictList::iterator itr = all_loaded_params[i]->begin();
+        gsparams::DictList::iterator itr = all_loaded_params[i].second->begin();
         int j = 0;
-        while(itr!=all_loaded_params[i]->end()){
+        while(itr!=all_loaded_params[i].second->end()){
             if(0 != path_vector[j].compare(itr.get_path())){
                 /*
                 std::cerr << par_init.my_pars["inter"] << std::endl;
@@ -725,7 +726,7 @@ int main( int argc, char* argv[] )
                 std::cerr << par_init.my_pars << std::endl;
                 std::cerr << (*all_loaded_params[i]) << std::endl;
                 */
-                throw std::invalid_argument("Error in one of the input parameter files (.par, free_fix, lower/upper bounds, etc.) \nTrying to compare SNOT objects, it seems that one of the inputs is misordered.  " + path_vector[j] + " is not " + itr.get_path());
+                throw std::invalid_argument("Error in one of the input parameter files (.par, free_fix, lower/upper bounds, etc.) \nTrying to compare SNOT objects, it seems that one of the inputs is misordered.  starting_parameters" + path_vector[j] + " is not " + all_loaded_params[i].first + itr.get_path() + " ");
             }
             ++itr;
             j++;


### PR DESCRIPTION
This totally invalidates previous results from the "new_storage" branch.
I alwasy test new branches against old branches though, so this may hint
that the output was matching older versions. Maybe a similar problem
existed before. >.<

The reason this is a problem is that code does not check to see which
factors intereact before checking factorIntMat, a non-interaction should
be 1.0 and the code just expects those elements of factorIntMat to
contain 1.0.

Initialize to 1.0, then populate.